### PR TITLE
fix(BUILD-4834): include the build number in the version when issuing SNS message

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export AWS_PROFILE=burgr-dev-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/platform-devinfra-squad
+* @sonarsource/platform-devinfra-squad

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -1,3 +1,5 @@
+name: Integration tests
+
 on:
   pull_request:
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
----
+name: Pre-commit checks
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/releasability_checks.yml
+++ b/.github/workflows/releasability_checks.yml
@@ -1,4 +1,4 @@
-name: Manually execute releasability checks
+name: Execute releasability checks
 
 on:
   workflow_dispatch:

--- a/.github/workflows/releasability_checks.yml
+++ b/.github/workflows/releasability_checks.yml
@@ -30,8 +30,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4.1.1
       - name: Trigger releasability checks
-        uses: SonarSource/gh-action_releasability@master
+        uses: ./
         with:
           organization: ${{ github.event.inputs.organization }}
           repository: ${{ github.event.inputs.repository }}

--- a/action.yml
+++ b/action.yml
@@ -46,11 +46,11 @@ runs:
         pip install pipenv
         pipenv install
       shell: bash
-      working-directory: ${{ github.action_path}}
+      working-directory: ${{ github.action_path }}
     - name: Trigger releasability checks
       id: checks
       shell: bash
-      working-directory: ${{ github.action_path}}
+      working-directory: ${{ github.action_path }}
       run: pipenv run releasability
       env:
         INPUT_ORGANIZATION: ${{ inputs.organization }}

--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -137,7 +137,6 @@ class ReleasabilityService:
 
         now = time.time()
         while len(checks_awaiting_result) > 0 and not has_exceeded_timeout(now, ReleasabilityService.FETCH_CHECK_RESULT_TIMEOUT_SECONDS):
-            print("fetch SQS messages ...")
             filtered_messages = self._fetch_filtered_check_results(correlation_id)
             for message_payload in filtered_messages:
                 check_name = message_payload["checkName"]

--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -61,7 +61,6 @@ class ReleasabilityService:
     def start_releasability_checks(self, organization: str, repository: str, branch: str, version: str, commit_sha: str):
         self.check_input_parameters(version)
 
-        standardized_version = VersionHelper.extract_semantic_version(version)
         build_number = VersionHelper.extract_build_number(version)
 
         print(f"Starting releasability check: {organization}/{repository}#{version}@{commit_sha}")
@@ -72,7 +71,7 @@ class ReleasabilityService:
             organization=organization,
             project_name=repository,
             branch_name=branch,
-            version=standardized_version,
+            version=version,
             revision=commit_sha,
             build_number=build_number,
         )

--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -61,8 +61,6 @@ class ReleasabilityService:
     def start_releasability_checks(self, organization: str, repository: str, branch: str, version: str, commit_sha: str):
         self.check_input_parameters(version)
 
-        build_number = VersionHelper.extract_build_number(version)
-
         print(f"Starting releasability check: {organization}/{repository}#{version}@{commit_sha}")
 
         correlation_id = str(uuid.uuid4())
@@ -73,7 +71,6 @@ class ReleasabilityService:
             branch_name=branch,
             version=version,
             revision=commit_sha,
-            build_number=build_number,
         )
 
         response = self.session.client("sns").publish(
@@ -99,8 +96,9 @@ class ReleasabilityService:
         branch_name: str,
         revision: str,
         version: str,
-        build_number: int,
     ):
+
+        build_number = VersionHelper.extract_build_number(version)
 
         sns_request = {
             'uuid': correlation_id,

--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -10,15 +10,6 @@ class VersionHelper:
         return int(parts[3])
 
     @staticmethod
-    def extract_semantic_version(version) -> str:
-        parts = version.split('.')
-        if len(parts) < 3:
-            raise ValueError(f'The provided version {version}  does not follow semantic versioning '
-                             f'(at least 3 parts are required <MAJOR>.<MINOR>.<PATCH>)')
-
-        return f'{parts[0]}.{parts[1]}.{parts[2]}'
-
-    @staticmethod
     def is_valid_sonar_version(version: str) -> bool:
         if "." not in version:
             return False

--- a/tests/releasability/releasability_service_test.py
+++ b/tests/releasability/releasability_service_test.py
@@ -13,9 +13,8 @@ class ReleasabilityTest(unittest.TestCase):
         with patch('boto3.Session', return_value=session):
             organization = "sonar"
             project_name = "sonar-dummy"
-            version = "5.4.3"
+            version = "5.4.3.1234"
             sha = "434343443efdcaaa123232"
-            build_number = 42
             branch_name = "feat/some"
 
             releasability = ReleasabilityService()
@@ -29,7 +28,6 @@ class ReleasabilityTest(unittest.TestCase):
                 branch_name=branch_name,
                 version=version,
                 revision=sha,
-                build_number=build_number
             )
 
             assert request['uuid'] == uuid
@@ -37,7 +35,7 @@ class ReleasabilityTest(unittest.TestCase):
             assert request['repoSlug'] == "sonar/sonar-dummy"
             assert request['version'] == version
             assert request['vcsRevision'] == sha
-            assert request['artifactoryBuildNumber'] == build_number
+            assert request['artifactoryBuildNumber'] == 1234
             assert request['branchName'] == branch_name
 
     def test_start_releasability_checks_should_invoke_publish(self):

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -26,23 +26,6 @@ class VersionHelperTest(unittest.TestCase):
 
     @parameterized.expand([
         '42.2',
-        '55'
-    ])
-    def test_extract_semantic_version_should_raise_an_exception_given_the_provided_version_is_not_valid(self, invalid_version: str):
-        with self.assertRaises(ValueError):
-            VersionHelper.extract_semantic_version(invalid_version)
-
-    @parameterized.expand([
-        ('1.2.3.1234', '1.2.3'),
-        ('4.3.2', '4.3.2'),
-    ])
-    def test_extract_semantic_version_should_return_the_expected_semantic_version_given_valid_versions(self, valid_version: str,
-                                                                                               expected_semantic_version: str):
-        actual_semantic_version = VersionHelper.extract_semantic_version(valid_version)
-        self.assertEquals(actual_semantic_version, expected_semantic_version)
-
-    @parameterized.expand([
-        '42.2',
         '55',
         'some',
         '3.2.1',


### PR DESCRIPTION
* fix: include the build number in the version when issuing SNS message 
* fix: use the correct version of the action when running releasability_checks workflow
* chore: add .envrc file for development
* chore: remove unused code
* chore: update CODEOWNERS to match all files
* chore: rename workflows