### PR TITLE
BUILD-4915 Support release version format with a +

### DIFF
--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -82,10 +82,11 @@ class ReleasabilityService:
 
     @staticmethod
     def check_input_parameters(version: str):
-        if not VersionHelper.is_valid_sonar_version(version):
+        if not VersionHelper.is_valid_version(version):
             raise ValueError(
                 f"The provided version {version}  does not match the standardized format "
-                f"used commonly across the organization: <MAJOR>.<MINOR>.<PATCH>.<BUILD NUMBER>"
+                f"used commonly across the organization: <MAJOR>.<MINOR>.<PATCH>.<BUILD NUMBER> "
+                f"or the alternative format: <MAJOR>.<MINOR>.<PATCH>+<BUILD NUMBER>"
             )
 
     def _build_sns_request(

--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -2,11 +2,13 @@ class VersionHelper:
 
     @staticmethod
     def extract_build_number(version) -> int:
-        parts = version.split('.')
-        if len(parts) != 4:
+        if not VersionHelper.is_valid_version(version):
             raise ValueError(f'The provided version {version}  does not match the standardized format '
                              f'used commonly across the organization: <MAJOR>.<MINOR>.<PATCH>.<BUILD NUMBER>')
 
+        parts = VersionHelper._sanitize_version(version).split('.')
+        if len(parts) != 4:
+            raise ValueError(f'The split version {version} must contains 4 parts')
         return int(parts[3])
 
     @staticmethod
@@ -18,3 +20,22 @@ class VersionHelper:
             return False
 
         return True
+
+    @staticmethod
+    def is_valid_plus_signed_version(version: str) -> bool:
+
+        # This is an explicit requirement for project SLVSCODE
+        # see https://sonarsource.atlassian.net/browse/BUILD-4915 for more details
+
+        if "+" not in version:
+            return False
+
+        return VersionHelper.is_valid_sonar_version(VersionHelper._sanitize_version(version))
+
+    @staticmethod
+    def is_valid_version(version: str) -> bool:
+        return VersionHelper.is_valid_sonar_version(version) or VersionHelper.is_valid_plus_signed_version(version)
+
+    @staticmethod
+    def _sanitize_version(version: str) -> str:
+        return version.replace("+", ".")

--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -1,4 +1,8 @@
+import re
+
+
 class VersionHelper:
+    VERSION_NUMBER_PLUS_SIGN_REGEX = r"^(\d+)\.(\d+)\.(\d+)\+(\d+)$"
 
     @staticmethod
     def extract_build_number(version) -> int:
@@ -27,7 +31,7 @@ class VersionHelper:
         # This is an explicit requirement for project SLVSCODE
         # see https://sonarsource.atlassian.net/browse/BUILD-4915 for more details
 
-        if "+" not in version:
+        if not re.match(VersionHelper.VERSION_NUMBER_PLUS_SIGN_REGEX, version):
             return False
 
         return VersionHelper.is_valid_sonar_version(VersionHelper._sanitize_version(version))

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -25,6 +25,15 @@ class VersionHelperTest(unittest.TestCase):
         self.assertEquals(actual_build_number, expected_build_number)
 
     @parameterized.expand([
+        ('1.2.3+1234', 1234),
+        ('42.2.1+5433', 5433),
+    ])
+    def test_extract_build_number_should_return_the_expected_build_number_given_special_versions(self, valid_version: str,
+                                                                                                 expected_build_number: int):
+        actual_build_number = VersionHelper.extract_build_number(valid_version)
+        self.assertEquals(actual_build_number, expected_build_number)
+
+    @parameterized.expand([
         '42.2',
         '55',
         'some',
@@ -40,3 +49,51 @@ class VersionHelperTest(unittest.TestCase):
     def test_is_valid_sonar_version_should_return_true_given_valid_versions(self, valid_version):
         valid = VersionHelper.is_valid_sonar_version(valid_version)
         self.assertTrue(valid)
+
+    @parameterized.expand([
+        '42.2',
+        '55',
+        'some',
+        '3.2.1.43243',
+        '3.2.1',
+        '3.2.1-4323',
+        '3.2.1#4323',
+    ])
+    def test_is_valid_plus_signed_version_should_return_false_given_invalid_versions(self, invalid_version):
+        valid = VersionHelper.is_valid_plus_signed_version(invalid_version)
+        self.assertFalse(valid)
+
+    @parameterized.expand([
+        '3.2.1+12345',
+    ])
+    def test_is_valid_plus_signed_version_should_return_true_given_valid_versions(self, valid_version):
+        valid = VersionHelper.is_valid_plus_signed_version(valid_version)
+        self.assertTrue(valid)
+
+    @parameterized.expand([
+        '42.2',
+        '55',
+        'some',
+        '3.2.1',
+        '3+2+2',
+    ])
+    def test_is_valid_version_should_return_false_given_invalid_versions(self, invalid_version):
+        valid = VersionHelper.is_valid_version(invalid_version)
+        self.assertFalse(valid)
+
+    @parameterized.expand([
+        '3.2.1.12345',
+        '3.2.1+12345',
+    ])
+    def test_is_valid_version_should_return_true_given_valid_versions(self, valid_version):
+        valid = VersionHelper.is_valid_version(valid_version)
+        self.assertTrue(valid)
+
+    @parameterized.expand([
+        ('1.2.3+1234', '1.2.3.1234'),
+        ('1.2.1.5433', '1.2.1.5433'),
+    ])
+    def test_sanitize_version_should_transform_special_version_format_to_standardized_one(self, input_version: str,
+                                                                                                 expected_sanitized_version: str):
+        actual_sanitized_version = VersionHelper._sanitize_version(input_version)
+        self.assertEquals(actual_sanitized_version, expected_sanitized_version)

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -58,6 +58,7 @@ class VersionHelperTest(unittest.TestCase):
         '3.2.1',
         '3.2.1-4323',
         '3.2.1#4323',
+        '4+3.2.1000',
     ])
     def test_is_valid_plus_signed_version_should_return_false_given_invalid_versions(self, invalid_version):
         valid = VersionHelper.is_valid_plus_signed_version(invalid_version)


### PR DESCRIPTION
# BUILD-4915 Support release version format with a +

## Changes
* Version format will now also support a special format `<MAJOR>.<MINOR>.<PATCH>+<BUILD NUMBER>` required for sonarlint-vscode project
  That way we keep compatibility with what is done in gh_action-release and avoid breaking changes

## Side notes
The code include some comments and reference to ticket BUILD-4915 in order to remember why this was so implemented and be able to challenge it eventually in the future.

unit tests are in place and handle also this new format to ensure no refactoring breaks this format support.

## How was it tested ?

* Unit tests, there is change in the action itself nor the workflow so I am confident