### PR TITLE
BUILD-5228: add releasability checks to action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,33 @@ outputs:
   logs:
     description: Logs from releasability checks
     value: ${{ steps.checks.outputs.logs }}
+  releasabilityCheckDependencies:
+    description: Result from releasability check CheckDependencies
+    value: ${{ steps.checks.outputs.releasabilityCheckDependencies }}
+  releasabilityQA:
+    description: Result from releasability check QA
+    value: ${{ steps.checks.outputs.releasabilityQA }}
+  releasabilityJira:
+    description: Result from releasability check Jira
+    value: ${{ steps.checks.outputs.releasabilityJira }}
+  releasabilityWhiteSource:
+    description: Result from releasability check WhiteSource
+    value: ${{ steps.checks.outputs.releasabilityWhiteSource }}
+  releasabilityCheckPeacheeLanguagesStatistics:
+    description: Result from releasability check CheckPeacheeLanguagesStatistics
+    value: ${{ steps.checks.outputs.releasabilityCheckPeacheeLanguagesStatistics }}
+  releasabilityQualityGate:
+    description: Result from releasability check QualityGate
+    value: ${{ steps.checks.outputs.releasabilityQualityGate }}
+  releasabilityParentPOM:
+    description: Result from releasability check ParentPOM
+    value: ${{ steps.checks.outputs.releasabilityParentPOM }}
+  releasabilityGitHub:
+    description: Result from releasability check GitHub
+    value: ${{ steps.checks.outputs.releasabilityGitHub }}
+  releasabilityCheckManifestValues:
+    description: Result from releasability check CheckManifestValues
+    value: ${{ steps.checks.outputs.releasabilityCheckManifestValues }}
 runs:
   using: "composite"
   steps:

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,10 @@ def do_releasability_checks(organization: str, repository: str, branch: str, ver
         report = releasability.get_releasability_report(correlation_id)
         GithubActionHelper.set_output_logs(str(report))
 
+        for check in report.get_checks():
+            name = f'releasability{check.name}'
+            GithubActionHelper.set_output(name, check.state)
+
         if report.contains_error():
             print("::error::Releasability checks failed")
             GithubActionHelper.set_output_status("1")

--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -29,6 +29,7 @@ class ReleasabilityService:
     ARN_SNS = 'arn:aws:sns'
     ARN_SQS = 'arn:aws:sqs'
 
+    # Make sure to update the outputs in action.yml if this list changes
     EXPECTED_RELEASABILITY_CHECK_NAMES = {
         "CheckDependencies",
         "QA",


### PR DESCRIPTION
BUILD-5228: add releasability checks to action outputs