### PR TITLE
BUILD-5702 improve ux

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ slack_sdk = "*"
 boto3 = "*"
 dryable = "*"
 parameterized = "*"
+github-action-utils = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "94ccef24b62029616de5e1655570ac7614b08dcb8b7234290ac6ab943811a162"
+            "sha256": "6ecadc60537670edbe9d7c9a3b11b15d7fcf83bba94fd6fd189808965fd089d0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,7 +22,6 @@
                 "sha256:b8433d481d50b68a0162c0379c0dd4aabfc3d1ad901800beb5b87815997511c1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.34.144"
         },
         "botocore": {
@@ -144,6 +143,14 @@
             "index": "pypi",
             "version": "==1.2.0"
         },
+        "github-action-utils": {
+            "hashes": [
+                "sha256:8aa40d90b89d814004160bb7e90b42cc07b55f41f66e4a4a32766d26c9ca3d61",
+                "sha256:bc84bac22e8a25ebe86370b08ff2c174960e468e899ffd313cb09d19629acefb"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
@@ -166,7 +173,6 @@
                 "sha256:7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==0.9.0"
         },
         "polling": {
@@ -181,7 +187,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "requests": {
@@ -190,7 +196,6 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "s3transfer": {
@@ -206,7 +211,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "slack-sdk": {
@@ -215,7 +220,6 @@
                 "sha256:a120cc461e8ebb7d9175f171dbe0ded37a6878d9f7b96b28e4bad1227399047b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.31.0"
         },
         "urllib3": {
@@ -327,7 +331,6 @@
                 "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==8.2.2"
         },
         "pytest-cov": {
@@ -336,7 +339,6 @@
                 "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==5.0.0"
         },
         "tomli": {

--- a/src/main.py
+++ b/src/main.py
@@ -25,10 +25,10 @@ def do_releasability_checks(organization: str, repository: str, branch: str, ver
             set_output(name, check.state)
 
         if report.contains_error():
-            error("Releasability checks failed")
+            error(f"Releasability checks of {version} failed")
             GithubActionHelper.set_output_status("1")
         else:
-            notice("Releasability checks passed successfully")
+            notice(f"Releasability checks of {version} passed successfully")
             GithubActionHelper.set_output_status("0")
 
     except Exception as ex:

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import sys
 
 from releasability.releasability_service import ReleasabilityService
 from utils.github_action_helper import GithubActionHelper
+from github_action_utils import error, notice, set_output
 
 
 def do_releasability_checks(organization: str, repository: str, branch: str, version: str, commit_sha: str):
@@ -21,17 +22,17 @@ def do_releasability_checks(organization: str, repository: str, branch: str, ver
 
         for check in report.get_checks():
             name = f'releasability{check.name}'
-            GithubActionHelper.set_output(name, check.state)
+            set_output(name, check.state)
 
         if report.contains_error():
-            print("::error::Releasability checks failed")
+            error("Releasability checks failed")
             GithubActionHelper.set_output_status("1")
         else:
-            print("::notice::Releasability checks passed successfully")
+            notice("Releasability checks passed successfully")
             GithubActionHelper.set_output_status("0")
 
     except Exception as ex:
-        print(f"::error:: {ex}")
+        error(f"{ex}")
         GithubActionHelper.set_output_status("1")
         sys.exit(1)
 

--- a/src/utils/github_action_helper.py
+++ b/src/utils/github_action_helper.py
@@ -1,24 +1,14 @@
 import os
 import uuid
 
+from github_action_utils import set_output
+
 GITHUB_ACTION_OUTPUT_LOG_NAME = "logs"
 GITHUB_ACTION_OUTPUT_STATUS_NAME = "status"
 GITHUB_OUTPUT_ENVIRONMENT_NAME = "GITHUB_OUTPUT"
 
 
 class GithubActionHelper:
-
-    @staticmethod
-    def set_output(output_name, value):
-        """Sets the GitHub Action output.
-
-        Keyword arguments:
-        output_name - The name of the output
-        value - The value of the output
-        """
-        if GITHUB_OUTPUT_ENVIRONMENT_NAME in os.environ:
-            with open(os.environ[GITHUB_OUTPUT_ENVIRONMENT_NAME], "a") as output_stream:
-                print(f"{output_name}={value}", file=output_stream)
 
     @staticmethod
     def set_multiline_output(output_name, value):
@@ -41,4 +31,4 @@ class GithubActionHelper:
 
     @staticmethod
     def set_output_status(status):
-        GithubActionHelper.set_output(GITHUB_ACTION_OUTPUT_STATUS_NAME, status)
+        set_output(GITHUB_ACTION_OUTPUT_STATUS_NAME, status)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -16,47 +18,50 @@ class MainTest(unittest.TestCase):
 
     def test_do_releasability_checks_should_define_output_logs_given_it_performed_well(self):
         correlation_id = "fake-correlation-id"
+        with tempfile.NamedTemporaryFile(suffix="", prefix=os.path.basename(__file__)) as temp_file:
+            os.environ['GITHUB_OUTPUT'] = temp_file.name
+            with patch.object(ReleasabilityService, '__init__', return_value=None):
+                with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=correlation_id):
+                    report = ReleasabilityChecksReport([
+                        ReleasabilityCheckResult("check name", ReleasabilityCheckResult.CHECK_PASSED, "it works"),
+                    ])
+                    with patch.object(ReleasabilityService, 'get_releasability_report', return_value=report):
+                        organization = "some-org"
+                        repository = "some-repo"
+                        branch = "some-branch"
+                        version = "4.3.2.1"
+                        commit_sha = "ef1232ad12321"
 
-        with patch.object(ReleasabilityService, '__init__', return_value=None):
-            with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=correlation_id):
-                report = ReleasabilityChecksReport([
-                    ReleasabilityCheckResult("check name", ReleasabilityCheckResult.CHECK_PASSED, "it works"),
-                ])
-                with patch.object(ReleasabilityService, 'get_releasability_report', return_value=report):
-                    organization = "some-org"
-                    repository = "some-repo"
-                    branch = "some-branch"
-                    version = "4.3.2.1"
-                    commit_sha = "ef1232ad12321"
+                        with patch.object(GithubActionHelper,'set_output_logs') as mock_set_output_logs:
+                            with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
 
-                    with patch.object(GithubActionHelper,'set_output_logs') as mock_set_output_logs:
-                        with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
+                                do_releasability_checks(organization, repository, branch, version, commit_sha)
 
-                            do_releasability_checks(organization, repository, branch, version, commit_sha)
-
-                            mock_set_output_logs.assert_called_once_with("✅ check name  - it works")
+                                mock_set_output_logs.assert_called_once_with("✅ check name  - it works")
 
     def test_do_releasability_checks_should_define_output_logs_given_it_did_not_perform_well(self):
         correlation_id = "fake-correlation-id"
 
-        with patch.object(ReleasabilityService, '__init__', return_value=None):
-            with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=correlation_id):
-                report = ReleasabilityChecksReport([
-                    ReleasabilityCheckResult("check name", ReleasabilityCheckResult.CHECK_FAILED, "it failed"),
-                ])
-                with patch.object(ReleasabilityService, 'get_releasability_report', return_value=report):
-                    organization = "some-org"
-                    repository = "some-repo"
-                    branch = "some-branch"
-                    version = "4.3.2.1"
-                    commit_sha = "ef1232ad12321"
+        with tempfile.NamedTemporaryFile(suffix="", prefix=os.path.basename(__file__)) as temp_file:
+            os.environ['GITHUB_OUTPUT'] = temp_file.name
+            with patch.object(ReleasabilityService, '__init__', return_value=None):
+                with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=correlation_id):
+                    report = ReleasabilityChecksReport([
+                        ReleasabilityCheckResult("check name", ReleasabilityCheckResult.CHECK_FAILED, "it failed"),
+                    ])
+                    with patch.object(ReleasabilityService, 'get_releasability_report', return_value=report):
+                        organization = "some-org"
+                        repository = "some-repo"
+                        branch = "some-branch"
+                        version = "4.3.2.1"
+                        commit_sha = "ef1232ad12321"
 
-                    with patch.object(GithubActionHelper,'set_output_logs') as mock_set_output_logs:
-                        with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
+                        with patch.object(GithubActionHelper,'set_output_logs') as mock_set_output_logs:
+                            with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
 
-                            do_releasability_checks(organization, repository, branch, version, commit_sha)
+                                do_releasability_checks(organization, repository, branch, version, commit_sha)
 
-                            mock_set_output_logs.assert_called_once_with("❌ check name  - it failed")
+                                mock_set_output_logs.assert_called_once_with("❌ check name  - it failed")
     def test_do_releasability_checks_should_define_output_status_as_success_given_it_performed_well(self):
         correlation_id = "fake-correlation-id"
 

--- a/tests/utils/github_action_helper_test.py
+++ b/tests/utils/github_action_helper_test.py
@@ -6,13 +6,6 @@ from utils.github_action_helper import GithubActionHelper
 
 
 class GithubActionHelperTest(unittest.TestCase):
-    def test_set_output(self):
-        with tempfile.NamedTemporaryFile(suffix="", prefix=os.path.basename(__file__)) as temp_file:
-            os.environ['GITHUB_OUTPUT'] = temp_file.name
-
-            GithubActionHelper.set_output('function', 'output')
-
-            assert temp_file.read().decode("utf-8").strip() == "function=output"
 
     def test_set_multiline_output(self):
         with tempfile.NamedTemporaryFile(suffix="", prefix=os.path.basename(__file__)) as temp_file:


### PR DESCRIPTION
## Changes

Before:
![image](https://github.com/user-attachments/assets/dabb2db4-386e-48b4-ae87-5a620ab6f998)

After:
![image](https://github.com/user-attachments/assets/d2b2d33e-bd48-460a-aee5-cddb6044bb4a)


And yes, there are other ways to retrieve that version number. However, I think it's good to consider also having it there to increase UX and ease adoption.


- [x] Print the version that was checked against releasability checks
      That way as end user I am able to rapidly retrieve the version before doing a release

- [x] Use a library to manage GitHub toolkit (::error, ::notice etc)
      That way we don't have to test/maintain it ourself (This lib is in use in ci-aws-infra https://github.com/SonarSource/ci-aws-infra/pull/26)

## How was it tested?

On sonar-dummy: https://github.com/SonarSource/sonar-dummy/actions/runs/9956341151
