### PR TITLE
BUILD-5711 Fix gh-action_releasability releasability status generates warning

### DIFF
--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -21,7 +21,7 @@ runs:
         pipenv install
       shell: bash
       working-directory: ${{ github.action_path }}
-    - uses: octokit/request-action@v2.x
+    - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d # v2.3.1
       id: get_commit_status
       with:
         route: 'GET /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/commits/${{ github.sha }}/status'
@@ -63,7 +63,7 @@ runs:
         exit 1
       shell: bash
 
-    - uses: octokit/request-action@v2.x
+    - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d # v2.3.1
       name: Update Commit status to success
       with:
         route: 'POST /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/statuses/${{ github.sha }}'
@@ -75,7 +75,7 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     # Adding as a separate step so that we can enhance the description to include name of failed checks
-    - uses: octokit/request-action@v2.x
+    - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d # v2.3.1
       if: failure()
       name: Update Commit status to failure
       with:

--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -67,12 +67,12 @@ runs:
       name: Update Commit status to success
       with:
         route: 'POST /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/statuses/${{ github.sha }}'
-        state: "success"
-        target_url: "https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"
-        description: "✈ ${{ steps.find_version.outputs.version }} passed releasability checks"
-        context: "Releasability"
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        INPUT_STATE: "success"
+        INPUT_TARGET_URL: "https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"
+        INPUT_DESCRIPTION: "✈ ${{ steps.find_version.outputs.version }} passed releasability checks"
+        INPUT_CONTEXT: "Releasability"
 
     # Adding as a separate step so that we can enhance the description to include name of failed checks
     - uses: octokit/request-action@872c5c97b3c85c23516a572f02b31401ef82415d # v2.3.1
@@ -80,9 +80,9 @@ runs:
       name: Update Commit status to failure
       with:
         route: 'POST /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/statuses/${{ github.sha }}'
-        state: "failure"
-        target_url: "https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"
-        description: "✈ ${{ steps.find_version.outputs.version }} failed releasability checks"
-        context: "Releasability"
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        INPUT_STATE: "failure"
+        INPUT_TARGET_URL: "https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"
+        INPUT_DESCRIPTION: "✈ ${{ steps.find_version.outputs.version }} failed releasability checks"
+        INPUT_CONTEXT: "Releasability"


### PR DESCRIPTION
## Changes

- [x] Use env as inputs that way the warning no longer appears (This is supported by the action: https://github.com/octokit/request-action/blob/main/index.js#L68) And also documented here: https://github.com/octokit/request-action/issues/26#issuecomment-1041852450

### Misc changes

- [x] Use fixed version of octokit/request-action (SHA)
      That way it is immutable and ensure predictable outputs

## How was it tested?

- [x] Tested on sonar-dummy-oss: https://github.com/SonarSource/sonar-dummy-oss/actions/runs/9957891590

![image](https://github.com/user-attachments/assets/d5c4358b-06ad-4ae5-abca-579db5a4cad3)

before:
![image](https://github.com/user-attachments/assets/10855424-a575-4d3d-81a1-99b8d54393a7)
