### PR TITLE
BUILD-6539 Support x.x.x-xxxx format

### DIFF
--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -6,7 +6,8 @@ class VersionHelper:
         r'^(?:[a-zA-Z]+-)?'   # Optional ProjectName- prefix (required by sonar-scanner-azdo; see https://sonarsource.atlassian.net/browse/BUILD-5293)
         r'\d+\.\d+\.\d+'      # Major.Minor.Patch version
         r'(?:-M\d+)?'         # Optional -Mx suffix
-        r'[.+]'               # Separator (+ is required by sonarlint-vscode; see https://sonarsource.atlassian.net/browse/BUILD-4915)
+        r'[.+-]'              # Separator (+ is required by sonarlint-vscode; see https://sonarsource.atlassian.net/browse/BUILD-4915)
+                              # Separator (- is required by npmjs projects; npm version command do not support x.x.x.xxxx format)
         r'(\d+)$'             # Build number in a captured group
     )
 

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -34,12 +34,20 @@ class VersionHelperTest(unittest.TestCase):
         self.assertEquals(actual_build_number, expected_build_number)
 
     @parameterized.expand([
+        ('1.2.3-1234', 1234),
+        ('42.2.1-5433', 5433),
+    ])
+    def test_extract_build_number_should_return_the_expected_build_number_given_npm_friendly_versions(self, valid_version: str,
+                                                                                                 expected_build_number: int):
+        actual_build_number = VersionHelper.extract_build_number(valid_version)
+        self.assertEquals(actual_build_number, expected_build_number)
+
+    @parameterized.expand([
         '42.2',
         '55',
         'some',
         '3.2.1',
         '3+2+2',
-        '3.2.1-4323',
         '3.2.1#4323',
         '4+3.2.1000',
         'proj--3.2.1+1234',
@@ -54,6 +62,7 @@ class VersionHelperTest(unittest.TestCase):
         'proj-3.2.1.12345',
         '3.2.1-M99.12345',
         '3.2.1+12345',
+        '3.2.1-12345',
         'proj-3.2.1-M99.12345',
     ])
     def test_is_valid_sonar_version_should_raise_no_exception_given_valid_versions(self, valid_version):


### PR DESCRIPTION
## Changes
- [x] Support x.x.x-xxxx format - That way npmjs and npm version commands are supported

> npm version x.x.x.xxxx fails execution. But x.x.x-4321 works fine.

A similar approach has been choose by sonarlint-vscode which use x.x.x+4321.

Unfortunately using the `+` is not supported by npm so a new variant need to be whitelisted.


## How was it tested?

- [x] Updated version_helper_test.py to include some scenarios with the new format https://github.com/SonarSource/gh-action_releasability/actions/runs/11215824083/job/31173785539?pr=60