### PR TITLE
BUILD-10382 Add deploymentrole path for multiple roles

### DIFF
--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
       with:
         aws-region: eu-central-1
-        role-to-assume: "arn:aws:iam::064493320159:role/ReleasbilityChecksCICDRole"
+        role-to-assume: "arn:aws:iam::064493320159:role/deploymentroles/ReleasbilityChecksCICDRole"
 
     - name: Install requirements
       run: pip install pipenv

--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
       with:
         aws-region: eu-central-1
-        role-to-assume: "arn:aws:iam::064493320159:role/deploymentroles/ReleasbilityChecksCICDRole"
+        role-to-assume: "arn:aws:iam::064493320159:role/deploymentroles/ReleasbilityChecksCICDRoleV2"
 
     - name: Install requirements
       run: pip install pipenv


### PR DESCRIPTION
## Summary

Update IAM role ARN in the `releasability-status` action to include the `/deploymentroles/` path, matching the path change applied to `ReleasbilityChecksCICDRole` in [sonarsource-iam#2012](https://github.com/SonarSource/sonarsource-iam/pull/2012).

- `role/ReleasbilityChecksCICDRole` -> `role/deploymentroles/ReleasbilityChecksCICDRole`

## JIRA task link

https://sonarsource.atlassian.net/browse/BUILD-10382

🤖 Generated with [Claude Code](https://claude.com/claude-code)