### PR TITLE
BUILD-10876 add required-checks input for selective failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   commit-sha:
     description: The GitHub commit SHA to use
     required: true
+  required-checks:
+    description: Optional comma-separated check names that must be PASSED to fail/succeed the action
+    required: false
+    default: ""
   releasabily-env:
     description: For development purposes, the environment to use (prod, staging or dev). Defaults to production.
     required: false
@@ -126,6 +130,7 @@ runs:
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_COMMIT_SHA: ${{ inputs.commit-sha}}
+        INPUT_REQUIRED_CHECKS: ${{ inputs.required-checks }}
         PYTHONUNBUFFERED: "1" # that way logs are printed live
     - name: Print execution
       run: |

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,9 @@ from github_action_utils import error, notice, set_output
 
 def do_releasability_checks(organization: str, repository: str, branch: str, version: str, commit_sha: str):
     try:
+        required_checks_raw = os.getenv("INPUT_REQUIRED_CHECKS", "")
+        required_checks = {check.strip() for check in required_checks_raw.split(",") if check.strip()}
+
         releasability = ReleasabilityService()
 
         # Start both inline and lambda checks
@@ -27,7 +30,12 @@ def do_releasability_checks(organization: str, repository: str, branch: str, ver
             name = f'releasability{check.name}'
             set_output(name, check.state)
 
-        if report.contains_error():
+        if required_checks:
+            has_failure = report.contains_error_for(required_checks)
+        else:
+            has_failure = report.contains_error()
+
+        if has_failure:
             error(f"Releasability checks of {version} failed")
             GithubActionHelper.set_output_status("1")
         else:

--- a/src/releasability/releasability_checks_report.py
+++ b/src/releasability/releasability_checks_report.py
@@ -18,3 +18,10 @@ class ReleasabilityChecksReport:
 
     def contains_error(self) -> bool:
         return any(filter(lambda check: (check.passed is not True), self.__checks))
+
+    def contains_error_for(self, required_check_names: set[str]) -> bool:
+        return any(
+            check.passed is not True
+            for check in self.__checks
+            if check.name in required_check_names
+        )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -105,3 +105,66 @@ class MainTest(unittest.TestCase):
                             do_releasability_checks(organization, repository, branch, version, commit_sha)
 
                             mock_set_output_status.assert_called_once_with("1")
+
+    def test_do_releasability_checks_should_use_default_behavior_when_required_checks_is_empty(self):
+        correlation_id = "fake-correlation-id"
+
+        with patch.dict(os.environ, {"INPUT_REQUIRED_CHECKS": ""}, clear=False):
+            with patch.object(ReleasabilityService, '__init__', return_value=None):
+                with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=(correlation_id, [])):
+                    report = ReleasabilityChecksReport([
+                        ReleasabilityCheckResult("CheckDependencies", ReleasabilityCheckResult.CHECK_PASSED, "it works"),
+                        ReleasabilityCheckResult("QA", ReleasabilityCheckResult.CHECK_FAILED, "it failed"),
+                    ])
+                    with patch.object(ReleasabilityService, 'get_combined_report', return_value=report):
+                        organization = "some-org"
+                        repository = "some-repo"
+                        branch = "some-branch"
+                        version = "4.3.2.1"
+                        commit_sha = "ef1232ad12321"
+
+                        with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
+                            do_releasability_checks(organization, repository, branch, version, commit_sha)
+                            mock_set_output_status.assert_called_once_with("1")
+
+    def test_do_releasability_checks_should_pass_when_required_checks_pass_even_if_other_checks_fail(self):
+        correlation_id = "fake-correlation-id"
+
+        with patch.dict(os.environ, {"INPUT_REQUIRED_CHECKS": "CheckDependencies"}, clear=False):
+            with patch.object(ReleasabilityService, '__init__', return_value=None):
+                with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=(correlation_id, [])):
+                    report = ReleasabilityChecksReport([
+                        ReleasabilityCheckResult("CheckDependencies", ReleasabilityCheckResult.CHECK_PASSED, "it works"),
+                        ReleasabilityCheckResult("QA", ReleasabilityCheckResult.CHECK_FAILED, "it failed"),
+                    ])
+                    with patch.object(ReleasabilityService, 'get_combined_report', return_value=report):
+                        organization = "some-org"
+                        repository = "some-repo"
+                        branch = "some-branch"
+                        version = "4.3.2.1"
+                        commit_sha = "ef1232ad12321"
+
+                        with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
+                            do_releasability_checks(organization, repository, branch, version, commit_sha)
+                            mock_set_output_status.assert_called_once_with("0")
+
+    def test_do_releasability_checks_should_fail_when_required_checks_fail(self):
+        correlation_id = "fake-correlation-id"
+
+        with patch.dict(os.environ, {"INPUT_REQUIRED_CHECKS": "CheckDependencies"}, clear=False):
+            with patch.object(ReleasabilityService, '__init__', return_value=None):
+                with patch.object(ReleasabilityService, 'start_releasability_checks', return_value=(correlation_id, [])):
+                    report = ReleasabilityChecksReport([
+                        ReleasabilityCheckResult("CheckDependencies", ReleasabilityCheckResult.CHECK_FAILED, "it failed"),
+                        ReleasabilityCheckResult("QA", ReleasabilityCheckResult.CHECK_PASSED, "it works"),
+                    ])
+                    with patch.object(ReleasabilityService, 'get_combined_report', return_value=report):
+                        organization = "some-org"
+                        repository = "some-repo"
+                        branch = "some-branch"
+                        version = "4.3.2.1"
+                        commit_sha = "ef1232ad12321"
+
+                        with patch.object(GithubActionHelper, 'set_output_status') as mock_set_output_status:
+                            do_releasability_checks(organization, repository, branch, version, commit_sha)
+                            mock_set_output_status.assert_called_once_with("1")

--- a/tests/releasability/releasability_check_report_test.py
+++ b/tests/releasability/releasability_check_report_test.py
@@ -21,6 +21,42 @@ class ReleasabilityCheckReportTest(unittest.TestCase):
 
         self.assertFalse(report.contains_error())
 
+    def test_contains_error_for_should_return_false_given_required_check_passes(self):
+        report = ReleasabilityChecksReport([
+            self._build_successful_check("CheckDependencies")
+        ])
+
+        self.assertFalse(report.contains_error_for({"CheckDependencies"}))
+
+    def test_contains_error_for_should_return_true_given_required_check_fails(self):
+        report = ReleasabilityChecksReport([
+            self._build_failed_check("CheckDependencies")
+        ])
+
+        self.assertTrue(report.contains_error_for({"CheckDependencies"}))
+
+    def test_contains_error_for_should_ignore_non_required_failing_checks(self):
+        report = ReleasabilityChecksReport([
+            self._build_successful_check("CheckDependencies"),
+            self._build_failed_check("QA")
+        ])
+
+        self.assertFalse(report.contains_error_for({"CheckDependencies"}))
+
+    def test_contains_error_for_should_return_false_given_empty_required_set(self):
+        report = ReleasabilityChecksReport([
+            self._build_failed_check("CheckDependencies")
+        ])
+
+        self.assertFalse(report.contains_error_for(set()))
+
+    def test_contains_error_for_should_return_false_when_required_check_is_missing(self):
+        report = ReleasabilityChecksReport([
+            self._build_failed_check("QA")
+        ])
+
+        self.assertFalse(report.contains_error_for({"CheckDependencies"}))
+
     def test_get_checks_should_contain_all_added_checks(self):
         check_a = self._build_successful_check("check A")
         check_b = self._build_successful_check("check B")


### PR DESCRIPTION
## Summary
- add a new optional `required-checks` input to `gh-action_releasability`
- keep running all releasability checks, but fail only when required checks are not `PASSED`
- preserve backward compatibility when `required-checks` is omitted, and add unit tests for report filtering and main action behavior

Jira: PREQ-4978

## Test plan
- [x] Run `pipenv run pytest`
- [x] Verify existing behavior remains unchanged when `required-checks` is empty
- [x] Verify action succeeds when required checks pass even if other checks fail
- [x] Verify action fails when a required check fails