### PR TITLE
PREQ-6644: Update octokit/request-action to v3.0.0 for Node 24

### DIFF
--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -87,7 +87,7 @@ runs:
         echo "=========================="
       shell: bash
 
-    - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+    - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
       name: Update Commit status to success
       if: steps.find_version.outputs.version != ''
       with:


### PR DESCRIPTION
## Summary

- Update `octokit/request-action` from v2.4.0 (Node 20) to v3.0.0 (Node 24) in `releasability-status/action.yml`
- Fixes Node.js 20 deprecation warnings when consumers run `SonarSource/gh-action_releasability/releasability-status@v3`
- No API changes: same `route` input and environment variables for commit status updates

Jira: https://sonarsource.atlassian.net/browse/PREQ-6644

## Test plan

- [ ] CI build passes on this PR
- [ ] After merge and release (or v3 branch update), verify a consumer workflow (e.g. sonar-skunk) no longer shows the Node 20 deprecation warning for `octokit/request-action`