### PR TITLE
PREQ-7517: Add inline CheckVersionConsistency releasability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ for a list of checks and their description.
 - ParentPOM
 - GitHub
 - CheckManifestValues
+- CheckVersionConsistency (inline) — input Major.Minor.Patch must match Repox build-info module version
+- CheckLicenses (inline)
 
 ### Version 3 and Later
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ outputs:
   releasabilityCheckManifestValues:
     description: Result from releasability check CheckManifestValues
     value: ${{ steps.checks.outputs.releasabilityCheckManifestValues }}
+  releasabilityCheckVersionConsistency:
+    description: Result from releasability check CheckVersionConsistency
+    value: ${{ steps.checks.outputs.releasabilityCheckVersionConsistency }}
   releasabilityCheckLicenses:
     description: Result from releasability check CheckLicenses
     value: ${{ steps.checks.outputs.releasabilityCheckLicenses }}
@@ -78,6 +81,12 @@ runs:
       with:
         aws-region: eu-central-1
         role-to-assume: "arn:aws:iam::${{ env[inputs.releasabily-env] }}:role/deploymentroles/ReleasbilityChecksCICDRoleV2"
+    - name: Fetch Artifactory credentials for inline checks
+      id: artifactory_secrets
+      uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
     - name: Install requirements
       run: |
         pip install pipenv
@@ -126,6 +135,8 @@ runs:
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_COMMIT_SHA: ${{ inputs.commit-sha}}
+        ARTIFACTORY_URL: https://repox.jfrog.io/artifactory
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.artifactory_secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         PYTHONUNBUFFERED: "1" # that way logs are printed live
     - name: Print execution
       run: |

--- a/action.yml
+++ b/action.yml
@@ -135,7 +135,8 @@ runs:
         INPUT_BRANCH: ${{ inputs.branch }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_COMMIT_SHA: ${{ inputs.commit-sha}}
-        ARTIFACTORY_URL: https://repox.jfrog.io/artifactory
+        # Same Repox base URL as gh-action_release
+        ARTIFACTORY_URL: https://repox.jfrog.io/repox
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.artifactory_secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         PYTHONUNBUFFERED: "1" # that way logs are printed live
     - name: Print execution

--- a/src/releasability/checks/check_version_consistency.py
+++ b/src/releasability/checks/check_version_consistency.py
@@ -28,7 +28,23 @@ class CheckVersionConsistency(InlineCheck):
         build_number = VersionHelper.extract_build_number(context.version)
         input_mmp = VersionHelper.extract_major_minor_patch(context.version)
 
-        build_info = client.fetch_build_info(build_name, build_number)
+        try:
+            build_info = client.fetch_build_info(build_name, build_number)
+        except ArtifactoryClient.FetchError as e:
+            # Missing / differently named builds are common across repos — do not block.
+            # Auth and other infrastructure failures stay blocking (fail-closed).
+            if e.status_code == 404:
+                return ReleasabilityCheckResult(
+                    self.name,
+                    ReleasabilityCheckResult.CHECK_NOT_RELEVANT,
+                    f'could not fetch build-info for {build_name}:{build_number}: {e}',
+                )
+            return ReleasabilityCheckResult(
+                self.name,
+                ReleasabilityCheckResult.CHECK_ERROR,
+                f'could not fetch build-info for {build_name}:{build_number}: {e}',
+            )
+
         modules = build_info.get('modules') or []
         if not modules:
             return ReleasabilityCheckResult(
@@ -77,5 +93,10 @@ class CheckVersionConsistency(InlineCheck):
 
     @staticmethod
     def _extract_trailing_build_number(artifact_version: str) -> Optional[int]:
-        match = re.search(r'[.+-](\d+)$', artifact_version.strip())
+        # Require full Major.Minor.Patch[+optional -Mx]+separator+build to avoid
+        # treating the patch digit of '1.2.3' as a build number.
+        match = re.match(
+            r'^\d+\.\d+\.\d+(?:-M\d+)?[.+-](\d+)$',
+            artifact_version.strip(),
+        )
         return int(match.group(1)) if match else None

--- a/src/releasability/checks/check_version_consistency.py
+++ b/src/releasability/checks/check_version_consistency.py
@@ -1,0 +1,81 @@
+import re
+from typing import Optional
+
+from utils.artifactory_client import ArtifactoryClient
+from utils.version_helper import VersionHelper
+
+from ..inline_check import CheckContext, InlineCheck
+from ..releasability_check_result import ReleasabilityCheckResult
+
+
+class CheckVersionConsistency(InlineCheck):
+    """
+    Ensure the releasability input Major.Minor.Patch matches the Repox build-info
+    module version (same source used later by gh-action_release for CDN naming).
+    """
+
+    def __init__(self, artifactory_client: Optional[ArtifactoryClient] = None):
+        self._artifactory_client = artifactory_client
+
+    @property
+    def name(self) -> str:
+        return "CheckVersionConsistency"
+
+    def execute(self, context: CheckContext) -> ReleasabilityCheckResult:
+        client = self._artifactory_client or ArtifactoryClient.from_env()
+
+        build_name = VersionHelper.artifactory_build_name(context.repository, context.version)
+        build_number = VersionHelper.extract_build_number(context.version)
+        input_mmp = VersionHelper.extract_major_minor_patch(context.version)
+
+        build_info = client.fetch_build_info(build_name, build_number)
+        modules = build_info.get('modules') or []
+        if not modules:
+            return ReleasabilityCheckResult(
+                self.name,
+                ReleasabilityCheckResult.CHECK_ERROR,
+                f'build-info for {build_name}:{build_number} has no modules',
+            )
+
+        module_id = modules[0].get('id')
+        if not module_id:
+            return ReleasabilityCheckResult(
+                self.name,
+                ReleasabilityCheckResult.CHECK_ERROR,
+                f'first build-info module for {build_name}:{build_number} has no id',
+            )
+
+        artifact_version = VersionHelper.parse_module_version(module_id)
+        artifact_mmp = VersionHelper.major_minor_patch_from_artifact_version(artifact_version)
+
+        if input_mmp != artifact_mmp:
+            return ReleasabilityCheckResult(
+                self.name,
+                ReleasabilityCheckResult.CHECK_FAILED,
+                (
+                    f'input version Major.Minor.Patch ({input_mmp}) does not match '
+                    f'Repox build-info module version ({artifact_mmp})'
+                ),
+            )
+
+        artifact_build = self._extract_trailing_build_number(artifact_version)
+        if artifact_build is not None and artifact_build != build_number:
+            return ReleasabilityCheckResult(
+                self.name,
+                ReleasabilityCheckResult.CHECK_FAILED,
+                (
+                    f'input build number ({build_number}) does not match '
+                    f'Repox build-info module build number ({artifact_build})'
+                ),
+            )
+
+        return ReleasabilityCheckResult(
+            self.name,
+            ReleasabilityCheckResult.CHECK_PASSED,
+            f'input {input_mmp}.{build_number} matches Repox module {artifact_version}',
+        )
+
+    @staticmethod
+    def _extract_trailing_build_number(artifact_version: str) -> Optional[int]:
+        match = re.search(r'[.+-](\d+)$', artifact_version.strip())
+        return int(match.group(1)) if match else None

--- a/src/releasability/releasability_service.py
+++ b/src/releasability/releasability_service.py
@@ -213,9 +213,11 @@ class ReleasabilityService:
         """Register all inline checks with the registry."""
         # Import inline checks here to avoid circular imports
         from releasability.checks.check_licenses import CheckLicenses
+        from releasability.checks.check_version_consistency import CheckVersionConsistency
 
         # Register inline checks
         self.check_registry.register_inline_check(CheckLicenses())
+        self.check_registry.register_inline_check(CheckVersionConsistency())
 
         logger.info(f"Registered {len(self.check_registry.get_inline_check_names())} inline checks")
 

--- a/src/utils/artifactory_client.py
+++ b/src/utils/artifactory_client.py
@@ -1,0 +1,41 @@
+import os
+from typing import Any, Optional
+
+import requests
+
+
+class ArtifactoryClient:
+    """Minimal Repox client for fetching build-info."""
+
+    def __init__(self, base_url: str, access_token: str, session: Optional[requests.Session] = None):
+        self.base_url = base_url.rstrip('/')
+        self.access_token = access_token
+        self.session = session or requests.Session()
+
+    @classmethod
+    def from_env(cls) -> "ArtifactoryClient":
+        base_url = os.getenv('ARTIFACTORY_URL')
+        access_token = os.getenv('ARTIFACTORY_ACCESS_TOKEN')
+        if not base_url or not access_token:
+            raise ValueError(
+                'ARTIFACTORY_URL and ARTIFACTORY_ACCESS_TOKEN must be set for CheckVersionConsistency'
+            )
+        return cls(base_url, access_token)
+
+    def fetch_build_info(self, build_name: str, build_number: int | str) -> dict[str, Any]:
+        url = f'{self.base_url}/api/build/{build_name}/{build_number}'
+        response = self.session.get(
+            url,
+            headers={'X-JFrog-Art-Api': self.access_token},
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f'Failed to fetch build-info for {build_name}:{build_number} '
+                f'(HTTP {response.status_code})'
+            )
+        payload = response.json()
+        build_info = payload.get('buildInfo')
+        if not build_info:
+            raise RuntimeError(f'No buildInfo in response for {build_name}:{build_number}')
+        return build_info

--- a/src/utils/artifactory_client.py
+++ b/src/utils/artifactory_client.py
@@ -1,11 +1,19 @@
 import os
 from typing import Any, Optional
+from urllib.parse import quote
 
 import requests
 
 
 class ArtifactoryClient:
     """Minimal Repox client for fetching build-info."""
+
+    class FetchError(RuntimeError):
+        """Raised when build-info cannot be fetched."""
+
+        def __init__(self, message: str, status_code: Optional[int] = None):
+            super().__init__(message)
+            self.status_code = status_code
 
     def __init__(self, base_url: str, access_token: str, session: Optional[requests.Session] = None):
         self.base_url = base_url.rstrip('/')
@@ -23,19 +31,23 @@ class ArtifactoryClient:
         return cls(base_url, access_token)
 
     def fetch_build_info(self, build_name: str, build_number: int | str) -> dict[str, Any]:
-        url = f'{self.base_url}/api/build/{build_name}/{build_number}'
+        # Align with gh-action_release Artifactory client (Bearer access token).
+        encoded_name = quote(str(build_name), safe='')
+        encoded_number = quote(str(build_number), safe='')
+        url = f'{self.base_url}/api/build/{encoded_name}/{encoded_number}'
         response = self.session.get(
             url,
-            headers={'X-JFrog-Art-Api': self.access_token},
+            headers={'Authorization': f'Bearer {self.access_token}'},
             timeout=30,
         )
         if response.status_code != 200:
-            raise RuntimeError(
+            raise self.FetchError(
                 f'Failed to fetch build-info for {build_name}:{build_number} '
-                f'(HTTP {response.status_code})'
+                f'(HTTP {response.status_code})',
+                status_code=response.status_code,
             )
         payload = response.json()
         build_info = payload.get('buildInfo')
         if not build_info:
-            raise RuntimeError(f'No buildInfo in response for {build_name}:{build_number}')
+            raise self.FetchError(f'No buildInfo in response for {build_name}:{build_number}')
         return build_info

--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -11,6 +11,14 @@ class VersionHelper:
         r'(\d+)$'             # Build number in a captured group
     )
 
+    # Groups: optional prefix, major.minor.patch[+optional -Mx], build number
+    VERSION_PARSE_REGEX = re.compile(
+        r'^(?:([a-zA-Z]+)-)?'
+        r'(\d+\.\d+\.\d+(?:-M\d+)?)'
+        r'[.+-]'
+        r'(\d+)$'
+    )
+
     @staticmethod
     def validate_version(version: str) -> None:
         """
@@ -56,3 +64,68 @@ class VersionHelper:
         # Extract the build number (the first capturing group in the regex)
         build_number = match.group(1)
         return int(build_number)
+
+    @staticmethod
+    def extract_project_prefix(version: str) -> str | None:
+        """Return the optional alphabetic project prefix (e.g. 'sqs'), or None."""
+        VersionHelper.validate_version(version)
+        match = VersionHelper.VERSION_PARSE_REGEX.match(version.strip())
+        return match.group(1) if match else None
+
+    @staticmethod
+    def extract_major_minor_patch(version: str) -> str:
+        """
+        Return Major.Minor.Patch from a releasability version string.
+
+        Examples:
+        - 'sqs-2026.4.0.125719' -> '2026.4.0'
+        - '1.2.3+4567' -> '1.2.3'
+        - '1.2.3-M1.4567' -> '1.2.3-M1'
+        """
+        VersionHelper.validate_version(version)
+        match = VersionHelper.VERSION_PARSE_REGEX.match(version.strip())
+        if not match:
+            raise ValueError(f'Unable to parse Major.Minor.Patch from version: {version}')
+        return match.group(2)
+
+    @staticmethod
+    def artifactory_build_name(repository: str, version: str) -> str:
+        """
+        Build name used to fetch Repox build-info (matches ops-releasability).
+
+        Prefixed versions use '{repository}-{prefix}' (e.g. sonar-enterprise-sqs).
+        """
+        prefix = VersionHelper.extract_project_prefix(version)
+        return f'{repository}-{prefix}' if prefix else repository
+
+    @staticmethod
+    def parse_module_version(module_id: str) -> str:
+        """
+        Extract the version coordinate from a Maven module id 'group:artifact:version'.
+        """
+        parts = module_id.split(':')
+        if len(parts) < 3 or not parts[-1]:
+            raise ValueError(f'Unable to parse version from module id: {module_id}')
+        return parts[-1]
+
+    @staticmethod
+    def major_minor_patch_from_artifact_version(artifact_version: str) -> str:
+        """
+        Normalize a Repox module version to Major.Minor.Patch.
+
+        Accepts dotted build versions and semver separators (+/-) before the build number.
+        """
+        match = re.match(
+            r'^(\d+\.\d+\.\d+(?:-M\d+)?)(?:[.+-]\d+)?$',
+            artifact_version.strip(),
+        )
+        if not match:
+            # Fallback: take first three numeric components
+            components = re.split(r'[.+-]', artifact_version.strip())
+            numeric = [c for c in components if c.isdigit()]
+            if len(numeric) < 3:
+                raise ValueError(
+                    f'Unable to parse Major.Minor.Patch from artifact version: {artifact_version}'
+                )
+            return f'{numeric[0]}.{numeric[1]}.{numeric[2]}'
+        return match.group(1)

--- a/src/utils/version_helper.py
+++ b/src/utils/version_helper.py
@@ -114,18 +114,14 @@ class VersionHelper:
         Normalize a Repox module version to Major.Minor.Patch.
 
         Accepts dotted build versions and semver separators (+/-) before the build number.
+        Fails closed on unexpected formats (no best-effort guessing).
         """
         match = re.match(
             r'^(\d+\.\d+\.\d+(?:-M\d+)?)(?:[.+-]\d+)?$',
             artifact_version.strip(),
         )
         if not match:
-            # Fallback: take first three numeric components
-            components = re.split(r'[.+-]', artifact_version.strip())
-            numeric = [c for c in components if c.isdigit()]
-            if len(numeric) < 3:
-                raise ValueError(
-                    f'Unable to parse Major.Minor.Patch from artifact version: {artifact_version}'
-                )
-            return f'{numeric[0]}.{numeric[1]}.{numeric[2]}'
+            raise ValueError(
+                f'Unable to parse Major.Minor.Patch from artifact version: {artifact_version}'
+            )
         return match.group(1)

--- a/tests/releasability/check_version_consistency_test.py
+++ b/tests/releasability/check_version_consistency_test.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from releasability.checks.check_version_consistency import CheckVersionConsistency
 from releasability.inline_check import CheckContext
 from releasability.releasability_check_result import ReleasabilityCheckResult
+from utils.artifactory_client import ArtifactoryClient
 
 
 class TestCheckVersionConsistency(unittest.TestCase):
@@ -63,6 +64,37 @@ class TestCheckVersionConsistency(unittest.TestCase):
 
         self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_ERROR)
         self.assertIn("no modules", result.message)
+
+    def test_not_relevant_when_build_info_missing(self):
+        self.client.fetch_build_info.side_effect = ArtifactoryClient.FetchError(
+            'not found', status_code=404
+        )
+        context = CheckContext("SonarSource", "demo", "master", "1.2.3.100", "abc123")
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_NOT_RELEVANT)
+
+    def test_errors_when_auth_fails(self):
+        self.client.fetch_build_info.side_effect = ArtifactoryClient.FetchError(
+            'unauthorized', status_code=401
+        )
+        context = CheckContext("SonarSource", "demo", "master", "1.2.3.100", "abc123")
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_ERROR)
+
+    def test_does_not_treat_patch_digit_as_build_number(self):
+        self.client.fetch_build_info.return_value = {
+            'modules': [{'id': 'org.sonarsource.demo:demo:1.2.3'}]
+        }
+        context = CheckContext("SonarSource", "demo", "master", "1.2.3.100", "abc123")
+
+        result = self.check.execute(context)
+
+        # No trailing build on module version → skip build-number comparison → PASS on MMP
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_PASSED)
 
 
 if __name__ == '__main__':

--- a/tests/releasability/check_version_consistency_test.py
+++ b/tests/releasability/check_version_consistency_test.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock
+
+from releasability.checks.check_version_consistency import CheckVersionConsistency
+from releasability.inline_check import CheckContext
+from releasability.releasability_check_result import ReleasabilityCheckResult
+
+
+class TestCheckVersionConsistency(unittest.TestCase):
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.check = CheckVersionConsistency(artifactory_client=self.client)
+
+    def test_check_name(self):
+        self.assertEqual(self.check.name, "CheckVersionConsistency")
+
+    def test_passes_when_input_matches_module_version(self):
+        self.client.fetch_build_info.return_value = {
+            'modules': [{'id': 'com.sonarsource.sonarqube:sonar-enterprise:2026.4.0.125719'}]
+        }
+        context = CheckContext(
+            "SonarSource", "sonar-enterprise", "branch-2026.4",
+            "sqs-2026.4.0.125719", "abc123",
+        )
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_PASSED)
+        self.client.fetch_build_info.assert_called_once_with("sonar-enterprise-sqs", 125719)
+
+    def test_fails_when_patch_differs(self):
+        self.client.fetch_build_info.return_value = {
+            'modules': [{'id': 'com.sonarsource.sonarqube:sonar-enterprise:2026.4.1.125719'}]
+        }
+        context = CheckContext(
+            "SonarSource", "sonar-enterprise", "branch-2026.4",
+            "sqs-2026.4.0.125719", "abc123",
+        )
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_FAILED)
+        self.assertIn("2026.4.0", result.message)
+        self.assertIn("2026.4.1", result.message)
+
+    def test_fails_when_build_number_differs(self):
+        self.client.fetch_build_info.return_value = {
+            'modules': [{'id': 'org.sonarsource.demo:demo:1.2.3.200'}]
+        }
+        context = CheckContext("SonarSource", "demo", "master", "1.2.3.100", "abc123")
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_FAILED)
+        self.assertIn("build number", result.message)
+
+    def test_errors_when_no_modules(self):
+        self.client.fetch_build_info.return_value = {'modules': []}
+        context = CheckContext("SonarSource", "demo", "master", "1.2.3.100", "abc123")
+
+        result = self.check.execute(context)
+
+        self.assertEqual(result.state, ReleasabilityCheckResult.CHECK_ERROR)
+        self.assertIn("no modules", result.message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/releasability/releasability_service_hybrid_test.py
+++ b/tests/releasability/releasability_service_hybrid_test.py
@@ -16,12 +16,14 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
         """Test that inline checks are registered on initialization."""
         inline_checks = self.service.check_registry.get_inline_check_names()
 
-        # Should have CheckLicenses registered
         self.assertIn("CheckLicenses", inline_checks)
+        self.assertIn("CheckVersionConsistency", inline_checks)
 
     def test_execute_inline_checks(self):
         """Test executing inline checks."""
-        # Add a mock check for testing
+        # Replace CheckVersionConsistency with a mock to avoid Repox calls
+        mock_version_check = MockInlineCheck("CheckVersionConsistency")
+        self.service.check_registry.register_inline_check(mock_version_check)
         mock_check = MockInlineCheck("TestCheck")
         self.service.check_registry.register_inline_check(mock_check)
 
@@ -29,17 +31,15 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
             "sonar", "sonar-dummy", "master", "1.0.0.123", "abc123"
         )
 
-        # Should have results from both CheckLicenses and TestCheck
-        self.assertEqual(len(results), 2)
+        # CheckLicenses + CheckVersionConsistency + TestCheck
+        self.assertEqual(len(results), 3)
 
-        # Check that CheckLicenses result is present
         check_licenses_result = next(
             (r for r in results if r.name == "CheckLicenses"), None
         )
         self.assertIsNotNone(check_licenses_result)
         self.assertEqual(check_licenses_result.state, ReleasabilityCheckResult.CHECK_PASSED)
 
-        # Check that TestCheck result is present
         test_check_result = next(
             (r for r in results if r.name == "TestCheck"), None
         )
@@ -48,7 +48,10 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
 
     def test_execute_inline_checks_with_error(self):
         """Test that inline check errors are handled gracefully."""
-        # Create a check that raises an exception
+        # Replace CheckVersionConsistency with a mock to avoid Repox calls
+        mock_version_check = MockInlineCheck("CheckVersionConsistency")
+        self.service.check_registry.register_inline_check(mock_version_check)
+
         class FailingCheck(MockInlineCheck):
             def execute(self, context):
                 raise Exception("Test error")
@@ -60,10 +63,9 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
             "sonar", "sonar-dummy", "master", "1.0.0.123", "abc123"
         )
 
-        # Should have results from CheckLicenses and FailingCheck
-        self.assertEqual(len(results), 2)
+        # CheckLicenses + CheckVersionConsistency + FailingCheck
+        self.assertEqual(len(results), 3)
 
-        # Check that FailingCheck result has ERROR state
         failing_result = next(
             (r for r in results if r.name == "FailingCheck"), None
         )
@@ -121,6 +123,8 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
         mock_session.return_value.client.return_value = mock_sns_client
 
         service = ReleasabilityService()
+        # Avoid Repox calls from CheckVersionConsistency during this unit test
+        service.check_registry.register_inline_check(MockInlineCheck("CheckVersionConsistency"))
 
         correlation_id, inline_results = service.start_releasability_checks(
             "sonar", "sonar-dummy", "master", "1.0.0.123", "abc123"
@@ -136,6 +140,11 @@ class TestReleasabilityServiceHybrid(unittest.TestCase):
             (r for r in inline_results if r.name == "CheckLicenses"), None
         )
         self.assertIsNotNone(check_licenses_result)
+        version_check_result = next(
+            (r for r in inline_results if r.name == "CheckVersionConsistency"), None
+        )
+        self.assertIsNotNone(version_check_result)
+        self.assertEqual(version_check_result.state, ReleasabilityCheckResult.CHECK_PASSED)
 
 
 if __name__ == '__main__':

--- a/tests/utils/artifactory_client_test.py
+++ b/tests/utils/artifactory_client_test.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from utils.artifactory_client import ArtifactoryClient
+
+
+class TestArtifactoryClient(unittest.TestCase):
+
+    def test_from_env_requires_credentials(self):
+        with patch.dict('os.environ', {}, clear=True):
+            with self.assertRaises(ValueError):
+                ArtifactoryClient.from_env()
+
+    def test_from_env_reads_credentials(self):
+        with patch.dict(
+            'os.environ',
+            {
+                'ARTIFACTORY_URL': 'https://repox.jfrog.io/repox',
+                'ARTIFACTORY_ACCESS_TOKEN': 'token',
+            },
+            clear=True,
+        ):
+            client = ArtifactoryClient.from_env()
+            self.assertEqual(client.base_url, 'https://repox.jfrog.io/repox')
+            self.assertEqual(client.access_token, 'token')
+
+    def test_fetch_build_info_uses_bearer_auth(self):
+        session = MagicMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {'buildInfo': {'modules': []}}
+        session.get.return_value = response
+
+        client = ArtifactoryClient('https://repox.jfrog.io/repox', 'secret-token', session=session)
+        build_info = client.fetch_build_info('sonar-enterprise-sqs', 125719)
+
+        self.assertEqual(build_info, {'modules': []})
+        session.get.assert_called_once()
+        args, kwargs = session.get.call_args
+        self.assertEqual(
+            args[0],
+            'https://repox.jfrog.io/repox/api/build/sonar-enterprise-sqs/125719',
+        )
+        self.assertEqual(kwargs['headers'], {'Authorization': 'Bearer secret-token'})
+        self.assertEqual(kwargs['timeout'], 30)
+
+    def test_fetch_build_info_url_encodes_build_name(self):
+        session = MagicMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {'buildInfo': {'modules': []}}
+        session.get.return_value = response
+
+        client = ArtifactoryClient('https://repox.jfrog.io/repox', 'token', session=session)
+        client.fetch_build_info('repo with space', 1)
+
+        args, _kwargs = session.get.call_args
+        self.assertIn('repo%20with%20space', args[0])
+
+    def test_fetch_build_info_raises_on_http_error(self):
+        session = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        session.get.return_value = response
+
+        client = ArtifactoryClient('https://repox.jfrog.io/repox', 'token', session=session)
+        with self.assertRaises(ArtifactoryClient.FetchError) as ctx:
+            client.fetch_build_info('missing', 1)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_fetch_build_info_raises_when_build_info_missing(self):
+        session = MagicMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {}
+        session.get.return_value = response
+
+        client = ArtifactoryClient('https://repox.jfrog.io/repox', 'token', session=session)
+        with self.assertRaises(ArtifactoryClient.FetchError):
+            client.fetch_build_info('demo', 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -67,3 +67,29 @@ class VersionHelperTest(unittest.TestCase):
     ])
     def test_is_valid_sonar_version_should_raise_no_exception_given_valid_versions(self, valid_version):
         VersionHelper.validate_version(valid_version)
+
+    @parameterized.expand([
+        ('sqs-2026.4.0.125719', '2026.4.0'),
+        ('1.2.3+4567', '1.2.3'),
+        ('1.2.3-4567', '1.2.3'),
+        ('proj-3.2.1-M99.12345', '3.2.1-M99'),
+    ])
+    def test_extract_major_minor_patch(self, version, expected):
+        self.assertEqual(VersionHelper.extract_major_minor_patch(version), expected)
+
+    @parameterized.expand([
+        ('sonar-enterprise', 'sqs-2026.4.0.125719', 'sonar-enterprise-sqs'),
+        ('sonar-dummy', '1.2.3.100', 'sonar-dummy'),
+    ])
+    def test_artifactory_build_name(self, repository, version, expected):
+        self.assertEqual(VersionHelper.artifactory_build_name(repository, version), expected)
+
+    def test_major_minor_patch_from_artifact_version(self):
+        self.assertEqual(
+            VersionHelper.major_minor_patch_from_artifact_version('2026.4.1.125719'),
+            '2026.4.1',
+        )
+        self.assertEqual(
+            VersionHelper.major_minor_patch_from_artifact_version('1.2.3+4567'),
+            '1.2.3',
+        )

--- a/tests/utils/version_helper_test.py
+++ b/tests/utils/version_helper_test.py
@@ -93,3 +93,9 @@ class VersionHelperTest(unittest.TestCase):
             VersionHelper.major_minor_patch_from_artifact_version('1.2.3+4567'),
             '1.2.3',
         )
+
+    def test_major_minor_patch_from_artifact_version_fails_closed(self):
+        with self.assertRaises(ValueError):
+            VersionHelper.major_minor_patch_from_artifact_version('1.2.3.4.5.6')
+        with self.assertRaises(ValueError):
+            VersionHelper.major_minor_patch_from_artifact_version('not-a-version')


### PR DESCRIPTION
## Problem

During the SonarQube Server **2026.4** release, releasability was run with input `sqs-2026.4.0.125719` and went **green**, but the published CommercialDistribution binaries were named `2026.4.1.125719` (same build number, different patch).

Existing checks did not catch this:

- `VersionHelper` only validates version *format* and extracts the build number for Repox lookup
- `CheckManifestValues` only checks plugin JAR manifest keys (`Plugin-License` / `Plugin-Organization`)
- The `GitHub` check is about milestone tickets (and was `NOT_RELEVANT` on that run), not artifact naming
- Releasability is pre-publish; CDN zip names come later from Repox build-info via `gh-action_release`

So green releasability was consistent with current semantics — there was simply **no check** comparing input Major.Minor.Patch to the Repox build-info module version.

Incident cleanup of the mis-versioned binaries: [PREQ-7499](https://sonarsource.atlassian.net/browse/PREQ-7499)  
Gap filed by Łukasz: [PREQ-7517](https://sonarsource.atlassian.net/browse/PREQ-7517)  
Evidence run: [gh-action_releasability#29916340781](https://github.com/SonarSource/gh-action_releasability/actions/runs/29916340781)

## Solution

Add an **inline** releasability check `CheckVersionConsistency` (hybrid `InlineCheck` framework — no new ops-releasability lambda):

1. Resolve Repox build name (`{repository}` or `{repository}-{prefix}`, e.g. `sonar-enterprise-sqs`)
2. Fetch build-info with Vault Artifactory credentials (Bearer, same Repox base URL as `gh-action_release`)
3. Fail if input Major.Minor.Patch ≠ first module version (same `modules[0]` source release uses for CDN naming)
4. Also fail if build numbers differ when present on the module version
5. **HTTP 404** → `NOT_RELEVANT` (repos whose Repox build name ≠ GitHub repo); **auth/other fetch errors** → still `CHECK_ERROR` (fail-closed)

No new per-repo credential requirement: uses existing org-level `{REPO_OWNER}-private-reader` (same pattern as releasability caller workflows / release).

## Summary of changes

- New `CheckVersionConsistency` + `ArtifactoryClient` + `VersionHelper` MMP/build-name helpers
- Register inline check next to `CheckLicenses`; expose action output
- Unit tests covering the SQS patch-drift case and review follow-ups

## Test plan

- [x] Unit tests (`pytest tests/releasability/ tests/utils/`)
- [x] CI on this PR
- [x] Dogfood from this PR branch (`workflow_dispatch` → Execute releasability checks):
  - [sonar-dummy](https://github.com/SonarSource/gh-action_releasability/actions/runs/30264567497) — `15.0.2.10834` → **PASSED** (`input 15.0.2.10834 matches Repox module 15.0.2.10834`)
  - [sonar-enterprise / SQS](https://github.com/SonarSource/gh-action_releasability/actions/runs/30265620989) — `sqs-2026.5.0.126060` → **PASSED** (`input 2026.5.0.126060 matches Repox module 2026.5.0.126060`; prefixed build name `sonar-enterprise-sqs`)
  - [SQS mismatch](https://github.com/SonarSource/gh-action_releasability/actions/runs/30265197134) — `sqs-26.8.0.126060` (commit-status style) vs Repox `2026.5.0` → **FAILED as intended**
- [ ] After `v3` release: confirm production consumers pick up the check
- [ ] Update [End-user Documentation - Releasability](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3309240895/End-user+Documentation+-+Releasability) once released

[PREQ-7499]: https://sonarsource.atlassian.net/browse/PREQ-7499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PREQ-7517]: https://sonarsource.atlassian.net/browse/PREQ-7517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ