### PR TITLE
PREQ-7626: Pass Artifactory env to releasability-status checks

### DIFF
--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -43,6 +43,15 @@ runs:
         echo "This is expected if no version has been promoted yet."
         exit 0
 
+    # Required for inline CheckVersionConsistency (same wiring as root action.yml)
+    - name: Fetch Artifactory credentials for inline checks
+      if: steps.find_version.outcome == 'success'
+      id: artifactory_secrets
+      uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+
     - name: Trigger releasability checks
       if: steps.find_version.outcome == 'success'
       id: checks
@@ -57,6 +66,9 @@ runs:
         INPUT_BRANCH: ${{ github.ref_name }}
         INPUT_VERSION: ${{ steps.find_version.outputs.version }}
         INPUT_COMMIT_SHA: ${{ github.sha }}
+        # Same Repox base URL as root action.yml / gh-action_release
+        ARTIFACTORY_URL: https://repox.jfrog.io/repox
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.artifactory_secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         PYTHONUNBUFFERED: "1" # that way logs are printed live
 
     - name: Parse Releasability check output


### PR DESCRIPTION
## Summary
- `releasability-status` is the entrypoint used by analyzer repos; PREQ-7517 wired Artifactory env only in the root `action.yml`
- Fetch Vault private-reader token and pass `ARTIFACTORY_URL` / `ARTIFACTORY_ACCESS_TOKEN` into `pipenv run releasability` (same pattern as root action)
- Fixes org-wide `CheckVersionConsistency` failures: `ARTIFACTORY_URL and ARTIFACTORY_ACCESS_TOKEN must be set`

Jira: https://sonarsource.atlassian.net/browse/PREQ-7626

## Test plan
- [ ] Re-run Releasability Check on an affected analyzer repo (e.g. sonar-security) after merging / pointing at this SHA
- [ ] Confirm CheckVersionConsistency no longer errors on missing Artifactory env (may still fail for real version mismatches)
- [ ] Confirm optional Jira check behavior unchanged