### PR TITLE
PREQ-7626: Fix missing Artifactory env in releasability-status

### DIFF
--- a/releasability-status/action.yml
+++ b/releasability-status/action.yml
@@ -43,6 +43,17 @@ runs:
         echo "This is expected if no version has been promoted yet."
         exit 0
 
+    # Required by inline CheckVersionConsistency (same as root action.yml).
+    # releasability-status invokes pipenv run releasability directly and does not
+    # go through the root composite action, so credentials must be fetched here.
+    - name: Fetch Artifactory credentials for inline checks
+      if: steps.find_version.outcome == 'success'
+      id: artifactory_secrets
+      uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+
     - name: Trigger releasability checks
       if: steps.find_version.outcome == 'success'
       id: checks
@@ -57,6 +68,9 @@ runs:
         INPUT_BRANCH: ${{ github.ref_name }}
         INPUT_VERSION: ${{ steps.find_version.outputs.version }}
         INPUT_COMMIT_SHA: ${{ github.sha }}
+        # Same Repox base URL as gh-action_release / root action.yml
+        ARTIFACTORY_URL: https://repox.jfrog.io/repox
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.artifactory_secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         PYTHONUNBUFFERED: "1" # that way logs are printed live
 
     - name: Parse Releasability check output


### PR DESCRIPTION
## Summary
- Root cause of org-wide `CheckVersionConsistency` failures: [PREQ-7517](https://sonarsource.atlassian.net/browse/PREQ-7517) / 3.2.0 wired Vault Artifactory credentials only in the root `action.yml`.
- Analyzers call `releasability-status@v3`, which invokes `pipenv run releasability` directly and never set `ARTIFACTORY_URL` / `ARTIFACTORY_ACCESS_TOKEN` → `CHECK_ERROR: … must be set`.
- This PR fetches the same org `private-reader` token and passes it into the status entrypoint.

## Test plan
- [x] Diff matches root `action.yml` Vault secret path + Repox URL
- [ ] After merge + 3.2.1 / `v3` bump: re-run releasability-status on a failing analyzer (e.g. sonar-security) and confirm `CheckVersionConsistency` no longer errors on missing env
- [ ] Confirm matching / mismatch behavior still as designed when credentials are present

## Slack
https://sonarsource.slack.com/archives/C04CVEU7734/p1785224812617179

[PREQ-7517]: https://sonarsource.atlassian.net/browse/PREQ-7517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ